### PR TITLE
Specify build target in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,10 @@ version: "3.7"
 services:
   app:
     container_name: tcp-react
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: builder
     volumes:
       - ".:/app"
       - "/app/node_modules"
@@ -11,3 +14,4 @@ services:
     environment:
       - CHOKIDAR_USEPOLLING=true
     tty: true
+    command: npm start


### PR DESCRIPTION
Specify the build target stage as builder within docker-compose so we don't use the full production configuration during local development.

## Purpose

**Does the title of this PR accurately describe the changes/feature?**

Yes / No

**What was the motivation for these changes?**

Resolves: (issue/ticket number)

## Type of change

- [ ] Documentation update
- [ ] New feature (*non-breaking change which adds functionality*)
- [ ] Bug fix (*non-breaking change which fixes an issue*)
- [ ] Breaking change (*fix or feature that would cause existing functionality to not work as expected*)

## Testing

**Testing Tasks Completed:**

- [ ] This change includes unit tests for the changed/new code
- [ ] This has been tested locally, and does not break existing functionality

The lighthouse accessibility score for the page(s) this PR affects is: 

List any libraries added by this PR and compatible browsers for each library:
node-sass: 4.0.0

**Testing Tasks To Be Done:**

- [ ] This includes a documentation change, which should be peer reviewed
- [ ] This requires some manual testing, detailed below

Description of test scenario:
1. First...
1. Then...
1. Verify that...

## Other change related information

- [ ] This change requires a documentation update (*not included here*)
- [ ] This change is part of a larger change, and requires follow-up PR(s)
- [ ] This change updates `package.json` and will require installation to test locally
